### PR TITLE
Add unit tests and make services mockable

### DIFF
--- a/repositories/user_repository.go
+++ b/repositories/user_repository.go
@@ -12,7 +12,9 @@ import (
 	"go-api/models"
 )
 
-func FindAllUsers() ([]models.User, error) {
+var FindAllUsers = findAllUsers
+
+func findAllUsers() ([]models.User, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -34,7 +36,9 @@ func FindAllUsers() ([]models.User, error) {
 	return users, nil
 }
 
-func CreateUser(user *models.User) error {
+var CreateUser = createUser
+
+func createUser(user *models.User) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -50,7 +54,9 @@ func CreateUser(user *models.User) error {
 	return nil
 }
 
-func FindUserByEmail(email string) (*models.User, error) {
+var FindUserByEmail = findUserByEmail
+
+func findUserByEmail(email string) (*models.User, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -62,7 +68,9 @@ func FindUserByEmail(email string) (*models.User, error) {
 	return &user, nil
 }
 
-func UpdateUser(id primitive.ObjectID, data bson.M) error {
+var UpdateUser = updateUser
+
+func updateUser(id primitive.ObjectID, data bson.M) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 

--- a/services/user_service.go
+++ b/services/user_service.go
@@ -16,7 +16,9 @@ import (
 	"go-api/repositories"
 )
 
-func RegisterUser(user *models.User) error {
+var RegisterUser = registerUser
+
+func registerUser(user *models.User) error {
 	if strings.TrimSpace(user.Name) == "" || strings.TrimSpace(user.Email) == "" || strings.TrimSpace(user.Password) == "" {
 		return errors.New("Nome, email e senha são obrigatórios")
 	}
@@ -41,11 +43,15 @@ func RegisterUser(user *models.User) error {
 	return nil
 }
 
-func GetUsers() ([]models.User, error) {
+var GetUsers = getUsers
+
+func getUsers() ([]models.User, error) {
 	return repositories.FindAllUsers()
 }
 
-func Authenticate(email, password string) (*models.User, error) {
+var Authenticate = authenticate
+
+func authenticate(email, password string) (*models.User, error) {
 	user, err := repositories.FindUserByEmail(email)
 	if err != nil {
 		return nil, errors.New("Credenciais inválidas")
@@ -57,7 +63,9 @@ func Authenticate(email, password string) (*models.User, error) {
 	return user, nil
 }
 
-func GenerateToken(user *models.User) (string, error) {
+var GenerateToken = generateToken
+
+func generateToken(user *models.User) (string, error) {
 	claims := jwt.MapClaims{
 		"user_id": user.ID.Hex(),
 		"role":    user.Role,
@@ -67,7 +75,9 @@ func GenerateToken(user *models.User) (string, error) {
 	return token.SignedString([]byte(os.Getenv("JWT_SECRET")))
 }
 
-func UpdateUser(id primitive.ObjectID, data map[string]string) error {
+var UpdateUser = updateUser
+
+func updateUser(id primitive.ObjectID, data map[string]string) error {
 	update := make(map[string]interface{})
 	if name, ok := data["name"]; ok {
 		update["name"] = name

--- a/tests/jwt_middleware_test.go
+++ b/tests/jwt_middleware_test.go
@@ -1,0 +1,46 @@
+package tests
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"go-api/middlewares"
+	"go-api/models"
+	"go-api/services"
+)
+
+func TestJWTSuccess(t *testing.T) {
+	os.Setenv("JWT_SECRET", "secret")
+	token, _ := services.GenerateToken(&models.User{ID: primitive.NewObjectID(), Role: "user"})
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		if r.Context().Value(middlewares.ContextRole) != "user" {
+			t.Errorf("role ausente")
+		}
+	})
+
+	middlewares.JWT(next).ServeHTTP(w, r)
+
+	if !called || w.Code != 200 {
+		t.Fatalf("middleware falhou: %d", w.Code)
+	}
+}
+
+func TestJWTMissing(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	middlewares.JWT(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})).ServeHTTP(w, r)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("esperado %d, obteve %d", http.StatusUnauthorized, w.Code)
+	}
+}

--- a/tests/login_update_controller_test.go
+++ b/tests/login_update_controller_test.go
@@ -1,0 +1,120 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"go-api/controllers"
+	"go-api/middlewares"
+	"go-api/models"
+	"go-api/services"
+)
+
+func TestLoginSuccess(t *testing.T) {
+	authOrig := services.Authenticate
+	tokenOrig := services.GenerateToken
+	defer func() { services.Authenticate = authOrig; services.GenerateToken = tokenOrig }()
+
+	services.Authenticate = func(email, password string) (*models.User, error) {
+		return &models.User{ID: primitive.NewObjectID(), Role: "user"}, nil
+	}
+	services.GenerateToken = func(u *models.User) (string, error) { return "tok", nil }
+
+	creds := map[string]string{"email": "a@a.com", "password": "123"}
+	body, _ := json.Marshal(creds)
+	req := httptest.NewRequest("POST", "/login", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	controllers.Login(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status esperado %d, obteve %d", http.StatusOK, rr.Code)
+	}
+	var resp map[string]string
+	json.Unmarshal(rr.Body.Bytes(), &resp)
+	if resp["token"] != "tok" {
+		t.Fatalf("token incorreto: %v", resp)
+	}
+}
+
+func TestLoginInvalid(t *testing.T) {
+	authOrig := services.Authenticate
+	defer func() { services.Authenticate = authOrig }()
+	services.Authenticate = func(email, password string) (*models.User, error) {
+		return nil, errors.New("invalid")
+	}
+	body := []byte(`{"email":"a","password":"b"}`)
+	req := httptest.NewRequest("POST", "/login", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	controllers.Login(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("esperado %d, obteve %d", http.StatusUnauthorized, rr.Code)
+	}
+}
+
+func TestUpdateUserSuccess(t *testing.T) {
+	upOrig := services.UpdateUser
+	defer func() { services.UpdateUser = upOrig }()
+
+	var called bool
+	services.UpdateUser = func(id primitive.ObjectID, data map[string]string) error {
+		called = true
+		if data["name"] != "Novo" {
+			t.Errorf("payload incorreto: %v", data)
+		}
+		return nil
+	}
+
+	id := primitive.NewObjectID()
+	payload := map[string]string{"name": "Novo"}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest("PUT", "/users/"+id.Hex(), bytes.NewBuffer(body))
+	req = mux.SetURLVars(req, map[string]string{"id": id.Hex()})
+	ctx := context.WithValue(req.Context(), middlewares.ContextRole, "admin")
+	ctx = context.WithValue(ctx, middlewares.ContextUserID, id.Hex())
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	controllers.UpdateUser(rr, req)
+
+	if rr.Code != http.StatusNoContent || !called {
+		t.Fatalf("update falhou: status %d called %v", rr.Code, called)
+	}
+}
+
+func TestUpdateUserForbidden(t *testing.T) {
+	id := primitive.NewObjectID().Hex()
+	req := httptest.NewRequest("PUT", "/users/"+id, bytes.NewBuffer([]byte(`{}`)))
+	req = mux.SetURLVars(req, map[string]string{"id": id})
+	ctx := context.WithValue(req.Context(), middlewares.ContextRole, "user")
+	ctx = context.WithValue(ctx, middlewares.ContextUserID, "other")
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+	controllers.UpdateUser(rr, req)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("esperado %d, obteve %d", http.StatusForbidden, rr.Code)
+	}
+}
+
+func TestUpdateUserBadID(t *testing.T) {
+	req := httptest.NewRequest("PUT", "/users/abc", bytes.NewBuffer([]byte(`{}`)))
+	req = mux.SetURLVars(req, map[string]string{"id": "abc"})
+	ctx := context.WithValue(req.Context(), middlewares.ContextRole, "admin")
+	ctx = context.WithValue(ctx, middlewares.ContextUserID, "abc")
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+	controllers.UpdateUser(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("esperado %d, obteve %d", http.StatusBadRequest, rr.Code)
+	}
+}

--- a/tests/user_service_test.go
+++ b/tests/user_service_test.go
@@ -1,0 +1,116 @@
+package tests
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"golang.org/x/crypto/bcrypt"
+
+	"go-api/models"
+	"go-api/repositories"
+	"go-api/services"
+)
+
+func TestRegisterUserValidation(t *testing.T) {
+	err := services.RegisterUser(&models.User{Name: "", Email: "", Password: ""})
+	if err == nil || err.Error() != "Nome, email e senha são obrigatórios" {
+		t.Errorf("esperava erro de validação, obteve %v", err)
+	}
+}
+
+func TestRegisterUserDuplicate(t *testing.T) {
+	original := repositories.CreateUser
+	defer func() { repositories.CreateUser = original }()
+
+	repositories.CreateUser = func(u *models.User) error {
+		return mongo.WriteException{WriteErrors: []mongo.WriteError{{Code: 11000}}}
+	}
+
+	err := services.RegisterUser(&models.User{Name: "A", Email: "a@a.com", Password: "123"})
+	if err == nil || err.Error() != "E-mail já cadastrado" {
+		t.Errorf("esperava erro de duplicidade, obteve %v", err)
+	}
+}
+
+func TestRegisterUserSuccess(t *testing.T) {
+	original := repositories.CreateUser
+	defer func() { repositories.CreateUser = original }()
+
+	var created *models.User
+	repositories.CreateUser = func(u *models.User) error { created = u; return nil }
+
+	user := models.User{Name: "A", Email: "a@a.com", Password: "123"}
+	if err := services.RegisterUser(&user); err != nil {
+		t.Fatalf("erro inesperado: %v", err)
+	}
+	if created == nil || created.Password == "123" {
+		t.Errorf("senha não foi criptografada")
+	}
+	if user.Role != "user" {
+		t.Errorf("role padrão não aplicado")
+	}
+}
+
+func TestAuthenticateSuccess(t *testing.T) {
+	pwd, _ := bcrypt.GenerateFromPassword([]byte("123"), bcrypt.DefaultCost)
+	original := repositories.FindUserByEmail
+	defer func() { repositories.FindUserByEmail = original }()
+	repositories.FindUserByEmail = func(email string) (*models.User, error) {
+		return &models.User{Email: email, Password: string(pwd)}, nil
+	}
+	user, err := services.Authenticate("a@a.com", "123")
+	if err != nil || user.Email != "a@a.com" {
+		t.Fatalf("falha na autenticação: %v", err)
+	}
+}
+
+func TestAuthenticateInvalid(t *testing.T) {
+	original := repositories.FindUserByEmail
+	defer func() { repositories.FindUserByEmail = original }()
+	repositories.FindUserByEmail = func(email string) (*models.User, error) {
+		return nil, errors.New("not found")
+	}
+	if _, err := services.Authenticate("a@a.com", "123"); err == nil {
+		t.Fatal("esperava erro para usuário inexistente")
+	}
+}
+
+func TestGenerateToken(t *testing.T) {
+	os.Setenv("JWT_SECRET", "secret")
+	id := primitive.NewObjectID()
+	token, err := services.GenerateToken(&models.User{ID: id, Role: "admin"})
+	if err != nil || token == "" {
+		t.Fatalf("token inválido: %v", err)
+	}
+}
+
+func TestUpdateUserNoData(t *testing.T) {
+	if err := services.UpdateUser(primitive.NewObjectID(), map[string]string{}); err == nil {
+		t.Fatal("esperava erro para payload vazio")
+	}
+}
+
+func TestUpdateUserSuccess(t *testing.T) {
+	original := repositories.UpdateUser
+	defer func() { repositories.UpdateUser = original }()
+
+	var gotID primitive.ObjectID
+	var gotData interface{}
+	repositories.UpdateUser = func(id primitive.ObjectID, data bson.M) error {
+		gotID = id
+		gotData = data
+		return nil
+	}
+
+	err := services.UpdateUser(primitive.NewObjectID(), map[string]string{"name": "X", "password": "123"})
+	if err != nil {
+		t.Fatalf("erro inesperado: %v", err)
+	}
+	if gotID.IsZero() || gotData == nil {
+		t.Fatal("update não chamado corretamente")
+	}
+}


### PR DESCRIPTION
## Summary
- make user and repo service functions variables for easier stubbing
- add service tests for user operations and token generation
- add controller tests for login and update user
- cover JWT middleware behaviour

## Testing
- `go test ./... -coverprofile coverage.out` *(fails: Forbidden from storage.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_68409308fb408323939366e5d397c648