### PR TITLE
Fix duplicated test names

### DIFF
--- a/tests/login_update_controller_test.go
+++ b/tests/login_update_controller_test.go
@@ -62,7 +62,7 @@ func TestLoginInvalid(t *testing.T) {
 	}
 }
 
-func TestUpdateUserSuccess(t *testing.T) {
+func TestUpdateUserControllerSuccess(t *testing.T) {
 	upOrig := services.UpdateUser
 	defer func() { services.UpdateUser = upOrig }()
 

--- a/tests/user_service_test.go
+++ b/tests/user_service_test.go
@@ -94,7 +94,7 @@ func TestUpdateUserNoData(t *testing.T) {
 	}
 }
 
-func TestUpdateUserSuccess(t *testing.T) {
+func TestUpdateUserServiceSuccess(t *testing.T) {
 	original := repositories.UpdateUser
 	defer func() { repositories.UpdateUser = original }()
 


### PR DESCRIPTION
## Summary
- rename TestUpdateUserSuccess functions so names are unique

## Testing
- `go test ./...` *(fails: github.com/klauspost/compress download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68418a7310d8832384f6cee9eb2ff1c7